### PR TITLE
Stage 2 typos 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "s1.closures": "tape './stage-1/closures-and-scope/exercise.test.js' | tap-spec",
     "s1.functions": "tape './stage-1/abstraction-with-functions/exercise.test.js' | tap-spec",
     "s2": "tape './stage-2/**/*.test.js' | tap-spec",
-    "s2.module": "tape './stage-2/module-pattern/exercise.test.js' | tap-spec",
+    "s2.modules": "tape './stage-2/module-pattern/exercise.test.js' | tap-spec",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/stage-2/module-pattern/exercise.js
+++ b/stage-2/module-pattern/exercise.js
@@ -31,7 +31,7 @@ var UrlParser = (function () {
     path: null,
 
     // a function that takes a URL and returns its query string
-    query: null,
+    querystring: null,
   };
 });
 

--- a/stage-2/module-pattern/exercise.test.js
+++ b/stage-2/module-pattern/exercise.test.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const tape = require('tape');
-const exercise = require('../../.solutions/stage-2/module-pattern/solution.js');
-// const exercise = require('./exercise.js');
+const exercise = require('./exercise.js');
 
 tape('Module Pattern', function (test) {
   test.test('UrlParser', function (t) {


### PR DESCRIPTION
Fixed typos on stage 2 ws:
- stage 2 test script in the `package.json` should be `s2.modules` to match the instructions in the workshop.
- the method that takes a URL and returns its query string should be called `querystring` to match the name in the test cases.
- in the test file, imported the functions from the exercise file not the solution file.